### PR TITLE
fix: wipe migrated config files too when clearing dead registrations

### DIFF
--- a/preflight-entrypoint.sh
+++ b/preflight-entrypoint.sh
@@ -21,9 +21,33 @@
 
 log() { echo "[preflight] $*"; }
 
+# The runner's IsConfigured()/HasCredentials() checks treat .runner_migrated /
+# .credentials_migrated as equivalent to the primary files, so a wipe must
+# remove all five or config.sh refuses to re-register while run.sh can't load
+# settings ("Value cannot be null. (Parameter 'configuredSettings')") — a
+# crash loop that never self-heals. The files are removed from /actions-runner
+# too: the writable layer survives restarts, and the upstream entrypoint's
+# persist-back step otherwise re-seeds the persist dir from it.
+wipe_registration() {
+  local dir="$1" f
+  for f in .runner .credentials .credentials_rsaparams .runner_migrated .credentials_migrated; do
+    rm -f "$dir/$f" "/actions-runner/$f"
+  done
+}
+
 preflight() {
   local dir="${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:-}"
   [ -n "$dir" ] || return 0
+
+  # Heal the wedged state left behind by a partial wipe (an older preflight or
+  # manual cleanup that removed .runner but not .runner_migrated): without
+  # .runner there is nothing to validate, and the orphaned migrated files
+  # alone block registration.
+  if [ ! -f "$dir/.runner" ] && [ -f "$dir/.runner_migrated" ]; then
+    log "orphaned .runner_migrated without .runner; removing it so registration can proceed"
+    wipe_registration "$dir"
+  fi
+
   [ -f "$dir/.runner" ] || return 0
   if [ -z "${ACCESS_TOKEN:-}" ]; then
     log "ACCESS_TOKEN not set; cannot validate persisted registration, leaving as-is"
@@ -86,7 +110,7 @@ preflight() {
     404)
       log "persisted runner agentId=${agent_id} no longer exists on ${github_host};" \
         "wiping persisted registration to force fresh ACCESS_TOKEN registration"
-      rm -f "$dir/.runner" "$dir/.credentials" "$dir/.credentials_rsaparams"
+      wipe_registration "$dir"
       ;;
     *)
       log "could not validate persisted runner (HTTP ${status:-none}); leaving as-is"


### PR DESCRIPTION
## Problem

`bump-android-nas.local` got stuck in an unrecoverable crash loop after the runner registration it had persisted (`agentId=1891`) was pruned server-side by GitHub while the host was offline.

The preflight from #77 correctly detected the 404 and wiped `.runner`, `.credentials`, and `.credentials_rsaparams` — but the persist dir also held a `.runner_migrated` (written by the runner's broker migration), which the wipe doesn't know about. The runner's `IsConfigured()` treats the migrated file as a valid config ([ConfigurationStore.cs](https://github.com/actions/runner/blob/main/src/Runner.Common/ConfigurationStore.cs)):

```csharp
bool configured = new FileInfo(_configFilePath).Exists || new FileInfo(_migratedConfigFilePath).Exists;
```

So `config.sh` refused to register ("already configured") while `run.sh` crashed loading the missing `.runner` (`Value cannot be null. (Parameter 'configuredSettings')`) — looping forever. The preflight can't recover either, since it gates on `.runner` existing.

## Fix

- The wipe now also removes `.runner_migrated` and `.credentials_migrated` (`IsConfigured()`/`HasCredentials()` treat them as equivalent to the primary files).
- The wipe also cleans the same files from `/actions-runner`: the container's writable layer survives restarts, and the upstream entrypoint's persist-back step re-seeds the persist dir from it (observed live — deleting the file from the volume alone got it immediately re-created on the next loop iteration).
- A preflight pass heals the already-wedged state (`.runner_migrated` present without `.runner`) left behind by images with the old wipe, so affected hosts recover on their own once they pull this image.

## Testing

- `bash -n` + shellcheck clean.
- Script-level test of the three paths: wedged state gets healed, empty persist dir is a no-op, healthy `.runner` without `ACCESS_TOKEN` is left untouched.
- The equivalent manual cleanup (removing `.runner_migrated` from both the volume and `/actions-runner`) unstuck the real crash-looping runner on nas.local, which registered fresh and immediately picked up a job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)